### PR TITLE
Reset error flag for the rediscontext struct

### DIFF
--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -410,6 +410,15 @@ wait_for_ready:
 
         c->flags |= REDIS_CONNECTED;
 
+	/* This is needed because c->err is set using __redisSetError on
+	 * connection failures. This can be called by various functions.
+	 * We shall have a clear function that would ideally clean the struct
+	 * of all past errors which have been put into or somehow only set the
+	 * error flag and message after looping through all IP addresses and
+	 * not finding any REDIS_OK.
+	 */
+        c->err = 0;
+
         freeaddrinfo(servinfo);
         return REDIS_OK;  // Need to return REDIS_OK if alright
     }


### PR DESCRIPTION
This will reset the error flag and make it work. However we need to figure out a clean way to clean err, errstr etc

Flow:

`
sentinel.c: redisAsyncConnectBind -> deps/hiredis/async.c: redisConnectBindNonBlock -> deps/hiredis/hiredis.c:     redisContextConnectBindTcp(c,ip,port,NULL,source_addr) -> deps/hiredis/net.c: _redisContextConnectTcp(c,
`